### PR TITLE
Added Search Blogs

### DIFF
--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -159,5 +159,40 @@ namespace TabloidCLI
                 }
             }
         }
+
+        public SearchResults<Blog> SearchBlogs(string tagName)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT b.* FROM Blog b
+                                        LEFT JOIN BlogTag bt on b.Id = bt.BlogId
+                                        LEFT JOIN Tag t on t.Id = bt.TagId
+                                        WHERE t.Name LIKE @tagName";
+
+                    cmd.Parameters.AddWithValue("@tagName", $"%{tagName}%");
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    SearchResults<Blog> results = new SearchResults<Blog>();
+
+                    while (reader.Read())
+                    {
+                        Blog blog = new Blog()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Title = reader.GetString(reader.GetOrdinal("Title")),
+                            Url = reader.GetString(reader.GetOrdinal("URL")),
+                        };
+                        results.Add(blog); 
+
+                    }
+
+                    reader.Close();
+                    return results;
+                }
+            }
+        }
     }
 }

--- a/TabloidCLI/UserInterfaceManagers/SearchManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchManager.cs
@@ -28,6 +28,7 @@ namespace TabloidCLI.UserInterfaceManagers
             switch (choice)
             {
                 case "1":
+                    SearchBlogs();
                     return this;
                 case "2":
                     SearchAuthors();
@@ -59,6 +60,19 @@ namespace TabloidCLI.UserInterfaceManagers
             {
                 results.Display();
             }
+        }
+
+        private void SearchBlogs()
+        {
+            Console.WriteLine("Tag>");
+
+            string tagName = Console.ReadLine() ?? "";
+
+            SearchResults<Blog> results = _tagRepository.SearchBlogs(tagName);
+
+            if (results.NoResultsFound) Console.WriteLine($"No results for {tagName}");
+            else results.Display(); 
+            
         }
     }
 }


### PR DESCRIPTION
# Description

This expands on SearchManager and adds functionality to search and get results by a tag's name for blogs. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

- Start the Application
- Confirm you're on `lj-branch`
- Open the TabloidCLI.sln solution in your IDE.
- Run the program.

From the main console menu, enter `7` to enter `Search by Tag`.  
From Search By Tag, enter `1` to Search Blogs by tag name. 

In Search By Tag:

- First, enter a search query tag name  that is expected to return an empty response. Ensure that the console notifies the user that there are no results for the query.
- Secondly, enter a search query tag name that is expected to return a valid, existing result. Ensure that the console displays the blogs that were found for the matching query. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
